### PR TITLE
Bugfix/runtime requirement in metadata section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires-python="3"
 requires = [
     "flit_core >=2,<3",
-    "unidecode",
     "pytest"
 ]
 build-backend = "flit_core.buildapi"
@@ -18,4 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules"
+]
+requires = [
+    "unidecode"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,5 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 requires = [
-    "unidecode"
+    "unidecode >=1,<2"
 ]


### PR DESCRIPTION
Hey @Lilykos , I'm using the library you are maintaining and it broke my builds today because its dependency `unidecode` was not installed automatically via pip. I've tested the proposed changes and validated them against the docs of flit. 

You can see here that run time requirements have to go into the metadata section in a separate `requires` list: https://flit.readthedocs.io/en/latest/pyproject_toml.html#metadata-section

The version limit is not strictly necessary and I couldn't find any mention in the `unidecode` project if they mark breaking changes by a major version increase or not, but I prefer to be on the somewhat safer side. :) 

This fixes https://github.com/Lilykos/pyphonetics/issues/3.